### PR TITLE
Preserve usergroup ordering for group detection

### DIFF
--- a/Classes/Hook/SwitchUserRoleHook.php
+++ b/Classes/Hook/SwitchUserRoleHook.php
@@ -69,7 +69,12 @@ class SwitchUserRoleHook
         $role = $this->backendUser->getSessionData('tx_begroupsroles_role');
         if ($role === null) {
             $role = 0;
-            $this->backendUser->user['tx_begroupsroles_groups'] = implode(',', $this->getUsergroups($this->backendUser->user[$this->backendUser->usergroup_column]));
+
+            $usergroups = $this->backendUser->user[$this->backendUser->usergroup_column];
+            $this->backendUser->user['tx_begroupsroles_groups'] = implode(',', array_unique(array_merge(
+                GeneralUtility::intExplode(',', $usergroups, true),
+                $this->getUsergroups($usergroups)
+            )));
             $queryBuilder = $this->connection->createQueryBuilder();
             $queryBuilder->update($this->backendUser->user_table)
                 ->where(

--- a/Tests/Functional/Backend/ToolbarItems/RoleSwitcherTest.php
+++ b/Tests/Functional/Backend/ToolbarItems/RoleSwitcherTest.php
@@ -70,7 +70,7 @@ class RoleSwitcherTest extends FunctionalTestCase
      */
     public function checkAccessReturnsFalseWhenBeUsersFlagSetWithoutRoles()
     {
-        $this->setUpBackendUserFromFixture(3);
+        $this->setUpBackendUserFromFixture(4);
         $roleSwitcher = new RoleSwitcher();
         $this->getDatabaseConnection()->updateArray('be_groups', ['pid' => 0], ['tx_begroupsroles_isrole' => 0]);
 
@@ -96,6 +96,7 @@ class RoleSwitcherTest extends FunctionalTestCase
         $this->setUpBackendUserFromFixture(3);
         $roleSwitcher = new RoleSwitcher();
 
+        $this->assertTrue($roleSwitcher->checkAccess());
         $this->assertContains('[All groups]', $roleSwitcher->getItem());
     }
 
@@ -104,7 +105,7 @@ class RoleSwitcherTest extends FunctionalTestCase
      */
     public function getItemNotReturnsAllGroupsLabelForLimitedUser()
     {
-        $this->setUpBackendUserFromFixture(4);
+        $this->setUpBackendUserFromFixture(5);
         $roleSwitcher = new RoleSwitcher();
 
         $this->assertTrue($roleSwitcher->checkAccess());
@@ -116,10 +117,10 @@ class RoleSwitcherTest extends FunctionalTestCase
      */
     public function getItemReturnsFirstGroupForLimitedUser()
     {
-        $this->setUpBackendUserFromFixture(4);
+        $this->setUpBackendUserFromFixture(5);
         $roleSwitcher = new RoleSwitcher();
 
         $this->assertTrue($roleSwitcher->checkAccess());
-        $this->assertContains('[Maintain News]', $roleSwitcher->getItem());
+        $this->assertContains('[Maintain Products]', $roleSwitcher->getItem());
     }
 }

--- a/Tests/Functional/Fixtures/Database/be_groups.xml
+++ b/Tests/Functional/Fixtures/Database/be_groups.xml
@@ -10,21 +10,35 @@
         <uid>2</uid>
         <pid>0</pid>
         <title>Advanced editors</title>
-        <subgroup>1</subgroup>
+        <subgroup>1,4</subgroup>
         <tx_begroupsroles_isrole>0</tx_begroupsroles_isrole>
     </be_groups>
     <be_groups>
         <uid>3</uid>
         <pid>0</pid>
         <title>Simple editors</title>
-        <subgroup>1,4</subgroup>
+        <subgroup>1</subgroup>
         <tx_begroupsroles_isrole>0</tx_begroupsroles_isrole>
     </be_groups>
     <be_groups>
         <uid>4</uid>
         <pid>0</pid>
+        <title>Maintain Content</title>
+        <subgroup>0</subgroup>
+        <tx_begroupsroles_isrole>1</tx_begroupsroles_isrole>
+    </be_groups>
+    <be_groups>
+        <uid>5</uid>
+        <pid>0</pid>
         <title>Maintain News</title>
         <subgroup>0</subgroup>
+        <tx_begroupsroles_isrole>1</tx_begroupsroles_isrole>
+    </be_groups>
+    <be_groups>
+        <uid>6</uid>
+        <pid>0</pid>
+        <title>Maintain Products</title>
+        <subgroup>2</subgroup>
         <tx_begroupsroles_isrole>1</tx_begroupsroles_isrole>
     </be_groups>
 </dataset>

--- a/Tests/Functional/Fixtures/Database/be_users.xml
+++ b/Tests/Functional/Fixtures/Database/be_users.xml
@@ -3,7 +3,7 @@
     <be_users>
         <uid>2</uid>
         <pid>0</pid>
-        <username>advanced_editor</username>
+        <username>advanced_editor_disabled</username>
         <usergroup>2</usergroup>
         <disableIPlock>1</disableIPlock>
         <tx_begroupsroles_enabled>0</tx_begroupsroles_enabled>
@@ -11,16 +11,24 @@
     <be_users>
         <uid>3</uid>
         <pid>0</pid>
-        <username>simple_editor</username>
-        <usergroup>3</usergroup>
+        <username>advance_editor_enabled</username>
+        <usergroup>2</usergroup>
         <disableIPlock>1</disableIPlock>
         <tx_begroupsroles_enabled>1</tx_begroupsroles_enabled>
     </be_users>
     <be_users>
         <uid>4</uid>
         <pid>0</pid>
-        <username>limited_editor</username>
+        <username>simple_editor</username>
         <usergroup>3</usergroup>
+        <disableIPlock>1</disableIPlock>
+        <tx_begroupsroles_enabled>1</tx_begroupsroles_enabled>
+    </be_users>
+    <be_users>
+        <uid>5</uid>
+        <pid>0</pid>
+        <username>limited_editor</username>
+        <usergroup>6,2,5</usergroup>
         <disableIPlock>1</disableIPlock>
         <tx_begroupsroles_enabled>1</tx_begroupsroles_enabled>
         <tx_begroupsroles_limit>1</tx_begroupsroles_limit>


### PR DESCRIPTION
Prepend usergroups with the users ones to preserve correct ordering.

Resolves: #17 